### PR TITLE
Implement annotation for endpoints with no behaviour

### DIFF
--- a/src/Routing/SimpleEndpoint.php
+++ b/src/Routing/SimpleEndpoint.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace Chimera\Mapping\Routing;
+
+use Chimera\Mapping\Validator;
+
+/**
+ * @Annotation
+ * @Target({"CLASS"})
+ */
+final class SimpleEndpoint extends Endpoint
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function validateAdditionalData(Validator $validator): void
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function defaultMethods(): array
+    {
+        return ['GET'];
+    }
+}

--- a/tests/Functional/Routing/SimpleEndpointTest.php
+++ b/tests/Functional/Routing/SimpleEndpointTest.php
@@ -1,0 +1,84 @@
+<?php
+declare(strict_types=1);
+
+namespace Chimera\Mapping\Tests\Functional\Routing;
+
+use Chimera\Mapping\Routing\SimpleEndpoint;
+use Chimera\Mapping\Tests\Functional\TestCase;
+use Doctrine\Common\Annotations\AnnotationException;
+use function assert;
+
+final class SimpleEndpointTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * @covers \Chimera\Mapping\Routing\SimpleEndpoint
+     * @covers \Chimera\Mapping\Routing\SimpleEndpoint
+     * @covers \Chimera\Mapping\Reader
+     */
+    public function defaultValueShouldBeConfiguredProperly(): void
+    {
+        $annotation = $this->readAnnotation(FetchBookRequestHandler::class, SimpleEndpoint::class);
+        assert($annotation instanceof SimpleEndpoint || $annotation === null);
+
+        self::assertInstanceOf(SimpleEndpoint::class, $annotation);
+        self::assertSame('/books/{id}', $annotation->path);
+        self::assertSame(['GET'], $annotation->methods);
+        self::assertSame('books.fetch', $annotation->name);
+        self::assertNull($annotation->app);
+    }
+
+    /**
+     * @test
+     *
+     * @covers \Chimera\Mapping\Routing\SimpleEndpoint
+     * @covers \Chimera\Mapping\Routing\SimpleEndpoint
+     * @covers \Chimera\Mapping\Reader
+     */
+    public function propertiesShouldBeConfiguredProperly(): void
+    {
+        $annotation = $this->readAnnotation(FindBooksRequestHandler::class, SimpleEndpoint::class);
+        assert($annotation instanceof SimpleEndpoint || $annotation === null);
+
+        self::assertInstanceOf(SimpleEndpoint::class, $annotation);
+        self::assertSame('/books', $annotation->path);
+        self::assertSame(['GET'], $annotation->methods);
+        self::assertSame('books.find', $annotation->name);
+        self::assertSame('my-app', $annotation->app);
+    }
+
+    /**
+     * @test
+     *
+     * @covers \Chimera\Mapping\Routing\SimpleEndpoint
+     * @covers \Chimera\Mapping\Routing\SimpleEndpoint
+     * @covers \Chimera\Mapping\Reader
+     */
+    public function exceptionShouldBeRaisedWhenRequiredPropertiesAreMissing(): void
+    {
+        $this->expectException(AnnotationException::class);
+        $this->readAnnotation(FindAuthorsRequestHandler::class, SimpleEndpoint::class);
+    }
+}
+
+/**
+ * @SimpleEndpoint("/books/{id}", name="books.fetch")
+*/
+final class FetchBookRequestHandler
+{
+}
+
+/**
+ * @SimpleEndpoint(path="/books", name="books.find", app="my-app")
+ */
+final class FindBooksRequestHandler
+{
+}
+
+/**
+ * @SimpleEndpoint
+ */
+final class FindAuthorsRequestHandler
+{
+}

--- a/tests/Unit/Routing/SimpleEndpointTest.php
+++ b/tests/Unit/Routing/SimpleEndpointTest.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+namespace Chimera\Mapping\Tests\Unit\Routing;
+
+use Chimera\Mapping\Routing\SimpleEndpoint;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \Chimera\Mapping\Routing\SimpleEndpoint
+ */
+final class SimpleEndpointTest extends TestCase
+{
+    private const ENDPOINT_DATA = ['path' => '/tests', 'name' => 'test'];
+
+    /**
+     * @test
+     *
+     * @covers ::__construct()
+     * @covers ::validateAdditionalData()
+     * @covers ::defaultMethods()
+     * @covers \Chimera\Mapping\Validator
+     * @covers \Chimera\Mapping\Routing\Endpoint
+     */
+    public function validateShouldNotRaiseExceptionsWhenStateIsValid(): void
+    {
+        $annotation = new SimpleEndpoint(self::ENDPOINT_DATA);
+        $annotation->validate('class A');
+
+        self::assertSame(['GET'], $annotation->methods);
+    }
+}


### PR DESCRIPTION
Classes with this annotations are going to be mapped directly as handlers of the HTTP application, without intermediate component.